### PR TITLE
Tor et al (non-mixnets) do not offer strong anonymity either

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <br>
       Obscurix is not affiliated with Arch Linux, the Tor Project, I2P, the Freenet Project or anything else. It is produced independently. <br>
       <br>
-      <b>Obscurix is not finished yet. It is still in alpha. Do not rely on it for strong anonymity or stability yet. </b> <br>
+      <b>Obscurix is not finished yet. It is still in alpha. Do not rely on it for anonymity or stability yet. </b> <br>
       <br>
       The source code can be found <a href="https://github.com/Obscurix/Obscurix">here</a>. <br>
       <br>


### PR DESCRIPTION
https://eprint.iacr.org/2017/954

In the field of anonymous communication protocols, "strong anonymity" resists global passive adversaries. Low latency, low bandwidth overhead onion routers like tor cannot reach that goal. Though, mix networks can.